### PR TITLE
Fix order `filled` check from operator AND to OR

### DIFF
--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -192,7 +192,7 @@ impl GlobalState {
         for i in 0..2u32.pow(self.order_levels as u32) {
             let candidate_pos = (start_pos + i) % 2u32.pow(self.order_levels as u32);
             let order = self.get_account_order_by_pos(account_id, candidate_pos);
-            let is_empty_or_filled = order.filled_buy >= order.total_buy && order.filled_sell >= order.total_sell;
+            let is_empty_or_filled = order.filled_buy >= order.total_buy || order.filled_sell >= order.total_sell;
             if is_empty_or_filled {
                 self.next_order_positions.insert(account_id, candidate_pos);
                 return;


### PR DESCRIPTION
Tries to fix an issue when I work on issue #20 .
A panic occurred on [code](https://github.com/Fluidex/rollup-state-manager/blob/master/src/state/global.rs#L201) when running the test via `tests/global_state/test.sh`.

It seems that the AND operation should be fixed to OR according to [circuits-code](https://github.com/Fluidex/circuits/blob/ea65adf7d54f08887dc4f0dcfe208f89d8794eeb/helper.ts/state-utils.ts#L77).
