### PR TITLE
feat: use par_iter in GlobalState

### DIFF
--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -8,6 +8,7 @@ use crate::types::primitives::Fr;
 use anyhow::bail;
 use ff::Field;
 use fnv::FnvHashMap;
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::{
     sync::{Arc, Mutex},
@@ -296,28 +297,32 @@ impl GlobalState {
     }
     pub fn batch_update(&mut self, updates: Vec<AccountUpdates>, parallel: bool) {
         if parallel {
-            let mut handlers = vec![];
             let balance_parallel = 2;
             let order_parallel = 1;
             let account_parallel = 2;
+
+            let (tx, rx) = crossbeam_channel::bounded::<(Arc<Mutex<Tree>>, Vec<(u32, Fr)>, usize)>(updates.len());
+
+            let set_job = thread::spawn(move || {
+                rx.into_iter().par_bridge().for_each(|(tree, updates, parallel)| {
+                    tree.lock().unwrap().set_value_parallel(&updates, parallel);
+                });
+            });
+
             for update in updates.clone() {
                 let account_id = update.account_id;
                 assert!(self.balance_trees.contains_key(&account_id), "set_token_balance");
                 let balance_tree = self.balance_trees.get_mut(&account_id).unwrap().clone();
                 let balance_updates = update.balance_updates;
-                handlers.push(thread::spawn(move || {
-                    balance_tree.lock().unwrap().set_value_parallel(&balance_updates, balance_parallel);
-                }));
+                tx.send((balance_tree, balance_updates, balance_parallel)).unwrap();
                 assert!(self.order_trees.contains_key(&account_id), "set_order_leaf_hash_raw");
                 let order_tree = self.order_trees.get_mut(&account_id).unwrap().clone();
                 let order_updates = update.order_updates;
-                handlers.push(thread::spawn(move || {
-                    order_tree.lock().unwrap().set_value_parallel(&order_updates, order_parallel);
-                }));
-            }
-            for handler in handlers {
-                handler.join().unwrap();
-            }
+                tx.send((order_tree, order_updates, order_parallel)).unwrap();
+            };
+
+            set_job.join().unwrap();
+
             let mut account_updates = vec![];
             for update in updates {
                 let account_hash = self.recalculate_account_state_hash(update.account_id);

--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -319,7 +319,7 @@ impl GlobalState {
                 let order_tree = self.order_trees.get_mut(&account_id).unwrap().clone();
                 let order_updates = update.order_updates;
                 tx.send((order_tree, order_updates, order_parallel)).unwrap();
-            };
+            }
 
             set_job.join().unwrap();
 


### PR DESCRIPTION
change of :
https://github.com/Fluidex/rollup-state-manager/blob/007130669384c16bd5258302b26a5589dcb8a55e/src/state/global.rs#L308

use `rayon::par_bridge`