### PR TITLE
Copy Test global-state to Bin main

### DIFF
--- a/.github/workflows/rollup_state_manager.yaml
+++ b/.github/workflows/rollup_state_manager.yaml
@@ -1,0 +1,59 @@
+name: integration-test
+
+on:
+  push:
+    branches:
+      - master
+      - prod
+      - release/*
+  pull_request:
+    branches:
+      - master
+      - prod
+      - release/*
+
+jobs:
+  rollup_state_manager:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo target
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install 1.51.0 toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.51.0
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Test rollup_state_manager
+        run: bash tests/rollup_state_manager/test.sh

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,15 +1,109 @@
-use rollup_state_manager::config;
+#![allow(dead_code)]
+#![allow(unreachable_patterns)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::unnecessary_wraps)]
+
+use anyhow::Result;
+use rollup_state_manager::state::global::{export_circuit, msg_loader, msg_processor};
+use rollup_state_manager::state::{GlobalState, WitnessGenerator};
+use rollup_state_manager::test_utils;
+use rollup_state_manager::test_utils::l2::L2Block;
+use rollup_state_manager::test_utils::messages::WrappedMessage;
+use std::fs::{self};
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn replay_msgs(
+    msg_receiver: crossbeam_channel::Receiver<WrappedMessage>,
+    block_sender: crossbeam_channel::Sender<L2Block>,
+) -> Option<std::thread::JoinHandle<anyhow::Result<()>>> {
+    Some(std::thread::spawn(move || {
+        let state = GlobalState::new(
+            *test_utils::params::BALANCELEVELS,
+            *test_utils::params::ORDERLEVELS,
+            *test_utils::params::ACCOUNTLEVELS,
+            *test_utils::params::VERBOSE,
+        );
+        let mut witgen = WitnessGenerator::new(state, *test_utils::params::NTXS, block_sender, *test_utils::params::VERBOSE);
+
+        println!("genesis root {}", witgen.root());
+
+        let mut processor = msg_processor::Processor::default();
+
+        let timing = Instant::now();
+        for msg in msg_receiver.iter() {
+            match msg {
+                WrappedMessage::BALANCE(balance) => {
+                    processor.handle_balance_msg(&mut witgen, balance);
+                }
+                WrappedMessage::TRADE(trade) => {
+                    let trade_id = trade.id;
+                    processor.handle_trade_msg(&mut witgen, trade);
+                    println!("trade {} test done", trade_id);
+                }
+                WrappedMessage::ORDER(order) => {
+                    processor.handle_order_msg(&mut witgen, order);
+                }
+                _ => {
+                    //other msg is omitted
+                }
+            }
+        }
+        witgen.flush_with_nop();
+        let block_num = witgen.get_block_generate_num();
+        println!(
+            "genesis {} blocks (TPS: {})",
+            block_num,
+            (*test_utils::params::NTXS * block_num) as f32 / timing.elapsed().as_secs_f32()
+        );
+        Ok(())
+    }))
+}
+
+pub fn run(src: &str) -> Result<()> {
+    let circuit_repo = fs::canonicalize(PathBuf::from("circuits")).expect("invalid circuits repo path");
+    let filepath = PathBuf::from(src);
+    let (msg_sender, msg_receiver) = crossbeam_channel::unbounded();
+    let (blk_sender, blk_receiver) = crossbeam_channel::unbounded();
+
+    let loader_thread = msg_loader::load_msgs_from_file(&filepath.to_str().unwrap(), msg_sender);
+
+    let replay_thread = replay_msgs(msg_receiver, blk_sender);
+
+    let blocks: Vec<_> = blk_receiver.iter().collect();
+
+    loader_thread.map(|h| h.join().expect("loader thread failed"));
+    replay_thread.map(|h| h.join().expect("replay thread failed"));
+
+    let component = test_utils::circuit::CircuitSource {
+        src: String::from("src/block.circom"),
+        main: format!(
+            "Block({}, {}, {}, {})",
+            *test_utils::params::NTXS,
+            *test_utils::params::BALANCELEVELS,
+            *test_utils::params::ORDERLEVELS,
+            *test_utils::params::ACCOUNTLEVELS
+        ),
+    };
+
+    let circuit_dir = export_circuit::export_circuit_and_testdata(&circuit_repo, blocks, component)?;
+
+    println!("export test cases to {}", circuit_dir.to_str().unwrap());
+
+    Ok(())
+}
+
+/*
+ * have a look at scripts/global_state_test.sh
+ */
 
 fn main() {
-    dotenv::dotenv().ok();
-    env_logger::init();
-    log::info!("state_keeper started");
-
-    let mut conf = config_rs::Config::new();
-    let config_file = dotenv::var("CONFIG").unwrap();
-    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
-    let settings: config::Settings = conf.try_into().unwrap();
-    log::debug!("{:?}", settings);
-
-    unimplemented!();
+    let default_test_file = "circuits/test/testdata/msgs_float.jsonl";
+    //let default_test_file = "tests/global_state/testdata/data001.txt";
+    let test_file = std::env::args().nth(1).unwrap_or_else(|| default_test_file.into());
+    match run(&test_file) {
+        Ok(_) => println!("global_state test_case generated"),
+        Err(e) => panic!("{:#?}", e),
+    }
 }

--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -12,6 +12,11 @@ use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
+pub mod export_circuit;
+pub mod msg_loader;
+pub mod msg_processor;
+mod types;
+
 pub struct BalanceProof {
     pub leaf: Fr,
     pub balance_path: Vec<[Fr; 1]>,

--- a/src/state/global/export_circuit.rs
+++ b/src/state/global/export_circuit.rs
@@ -1,9 +1,9 @@
 // TODO: move this file in main repo rather than test folder
 
+use crate::test_utils;
+use crate::test_utils::L2BlockSerde;
+use crate::types::l2;
 use anyhow::Result;
-use rollup_state_manager::test_utils;
-use rollup_state_manager::test_utils::L2BlockSerde;
-use rollup_state_manager::types::l2;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/state/global/msg_loader.rs
+++ b/src/state/global/msg_loader.rs
@@ -1,4 +1,4 @@
-use rollup_state_manager::test_utils::messages::{parse_msg, WrappedMessage};
+use crate::test_utils::messages::{parse_msg, WrappedMessage};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 pub fn load_msgs_from_file(

--- a/src/state/global/msg_processor.rs
+++ b/src/state/global/msg_processor.rs
@@ -1,10 +1,10 @@
+use crate::account::{Account, Signature};
+use crate::state::WitnessGenerator;
+use crate::test_utils::types::{get_token_id_by_name, prec_token_id};
+use crate::types::l2::{self, OrderInput, OrderSide};
+use crate::types::primitives::{u32_to_fr, Fr};
+use crate::types::{fixnum, matchengine::messages};
 use num::Zero;
-use rollup_state_manager::account::{Account, Signature};
-use rollup_state_manager::state::WitnessGenerator;
-use rollup_state_manager::test_utils::types::{get_token_id_by_name, prec_token_id};
-use rollup_state_manager::types::l2::{self, OrderInput, OrderSide};
-use rollup_state_manager::types::primitives::{u32_to_fr, Fr};
-use rollup_state_manager::types::{fixnum, matchengine::messages};
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::time::Instant;

--- a/src/state/global/types.rs
+++ b/src/state/global/types.rs
@@ -2,14 +2,14 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::large_enum_variant)]
 
+use crate::account::Signature;
+use crate::state::WitnessGenerator;
+use crate::test_utils::types::{get_token_id_by_name, prec_token_id};
+use crate::types;
+use crate::types::fixnum;
+use crate::types::l2::{self, OrderSide};
+use crate::types::primitives::{fr_to_decimal, u32_to_fr};
 use num::Zero;
-use rollup_state_manager::account::Signature;
-use rollup_state_manager::state::WitnessGenerator;
-use rollup_state_manager::test_utils::types::{get_token_id_by_name, prec_token_id};
-use rollup_state_manager::types;
-use rollup_state_manager::types::fixnum;
-use rollup_state_manager::types::l2::{self, OrderSide};
-use rollup_state_manager::types::primitives::{fr_to_decimal, u32_to_fr};
 use rust_decimal::Decimal;
 
 #[derive(Clone, Copy)]

--- a/tests/global_state/bench.rs
+++ b/tests/global_state/bench.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use ethers::prelude::coins_bip39::English;
 use rollup_state_manager::account::{self, Account};
+use rollup_state_manager::state::global::msg_processor;
 use rollup_state_manager::state::{GlobalState, WitnessGenerator};
 use rollup_state_manager::test_utils::{
     self,
@@ -16,9 +17,6 @@ use std::time::Instant;
 
 use pprof::protos::Message;
 use std::io::Write;
-
-mod msg_processor;
-mod types;
 
 //if we use nightly build, we are able to use bench test ...
 fn bench_global_state(_circuit_repo: &Path) -> Result<Vec<l2::L2Block>> {

--- a/tests/global_state/gen_testcase.rs
+++ b/tests/global_state/gen_testcase.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::unnecessary_wraps)]
 
 use anyhow::Result;
+use rollup_state_manager::state::global::{export_circuit, msg_loader, msg_processor};
 use rollup_state_manager::state::{GlobalState, WitnessGenerator};
 use rollup_state_manager::test_utils;
 use rollup_state_manager::test_utils::l2::L2Block;
@@ -12,11 +13,6 @@ use rollup_state_manager::test_utils::messages::WrappedMessage;
 use std::fs::{self};
 use std::path::PathBuf;
 use std::time::Instant;
-
-mod export_circuit;
-mod msg_loader;
-mod msg_processor;
-mod types;
 
 fn replay_msgs(
     msg_receiver: crossbeam_channel::Receiver<WrappedMessage>,

--- a/tests/rollup_state_manager/test.sh
+++ b/tests/rollup_state_manager/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -uex
+
+export NTXS=2;
+export BALANCELEVELS=2;
+export ORDERLEVELS=3;
+export ACCOUNTLEVELS=2;
+export VERBOSE=false;
+
+export RUST_BACKTRACE=full
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO_DIR=$DIR/"../.."
+cd $REPO_DIR
+
+# make sure submodule is correctly cloned!!
+git submodule update --init --recursive
+if [ -z ${CI+x} ]; then git pull --recurse-submodules; fi
+cargo run --bin rollup_state_manager # debug mode for fast compile
+
+cd $REPO_DIR/circuits; npm i
+snarkit --version || npm -g install snarkit
+snarkit test testdata/Block_$NTXS"_"$BALANCELEVELS"_"$ORDERLEVELS"_"$ACCOUNTLEVELS/ --force_recompile --backend=wasm


### PR DESCRIPTION
Part of issue #66 

### Summary

1. Moves files `export_circuit.rs`, `msg_loader.rs`, `msg_processor.rs` and `types.rs` from folder `tests/global_state` to a new folder `src/state/global`. They are marked as modules in `src/state/global.rs`.
2. Copies the all code from `tests/global_state/gen_testcase.rs` to `src/bin/main.rs`.
3. Adds file `.github/workflows/rollup_state_manager.yaml` for CI.