### PR TITLE
Separate Config file to development and staging `RUN_MODE`s

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
+RUN_MODE=development # development or staging
 RUST_BACKTRACE=1
 RUST_LOG=rollup_state_manager=debug
-CONFIG=config.yaml
 
 NTXS=2
 BALANCELEVELS=3

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,2 @@
+persist_dir: circuits/testdata/persist
+persist_every_n_block: 10000

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,5 +1,3 @@
 brokers: '127.0.0.1:9092'
 prover_cluster_db: postgres://coordinator:coordinator_AA9944@127.0.0.1:5433/prover_cluster
 rollup_state_manager_db: postgres://postgres:postgres_AA9944@127.0.0.1:5434/rollup_state_manager
-persist_dir: circuits/testdata/persist
-persist_every_n_block: 10000

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,0 +1,3 @@
+brokers: 'exchange-kafka.dingir-exchange:9092'
+prover_cluster_db: postgres://coordinator:coordinator_AA9944@prover-cluster-pq.prover-cluster/prover_cluster
+rollup_state_manager_db: postgres://postgres:postgres_AA9944@rollup-state-manager-pq.rollup-state-manager/rollup_state_manager

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,9 +22,15 @@ impl Settings {
     /// # panics
     /// if the `CONFIG` env var not exist or the file is corrupt, it panics.
     pub fn init_default() {
-        let mut conf = config_rs::Config::new();
-        let config_file = env::var("CONFIG").unwrap();
-        conf.merge(config_rs::File::with_name(&config_file)).unwrap();
+        // Initializes with `config/default.yaml`.
+        let mut conf = config_rs::Config::default();
+        conf.merge(config_rs::File::with_name("config/default")).unwrap();
+
+        // Merges with `config/RUN_MODE.yaml` (development as default).
+        let run_mode = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
+        conf.merge(config_rs::File::with_name(&format!("config/{}", run_mode)).required(false))
+            .unwrap();
+
         Self::set(conf.try_into().unwrap());
     }
 


### PR DESCRIPTION
Similar as https://github.com/Fluidex/dingir-exchange/pull/230

Adds ENV `RUN_MODE` to separate Config file to development and staging.