### PR TITLE
Integrate with `rollup-state-db` migrator of `common-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,10 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/Fluidex/common-rs?branch=master#f653d4ad11a9e35c6a6abce6915e9fe655e6485b"
+source = "git+https://github.com/Fluidex/common-rs?branch=master#d4c62b24eef75ae4e107ecd7575339883765fddc"
 dependencies = [
  "babyjubjub-rs",
+ "cfg-if",
  "ff_ce",
  "fnv",
  "futures",
@@ -1114,6 +1115,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde 1.0.126",
  "serde_json",
+ "sqlx",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crossbeam-channel = "0.5.1"
 dotenv = "0.15.0"
 env_logger = "0.5"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
-fluidex-common = { git = "https://github.com/Fluidex/common-rs", branch = "master", features = [ "kafka" ] }
+fluidex-common = { git = "https://github.com/Fluidex/common-rs", branch = "master", features = [ "kafka", "rollup-state-db" ] }
 futures = "0.3.13"
 hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/migrations/20210626034404_l2block.sql
+++ b/migrations/20210626034404_l2block.sql
@@ -1,6 +1,0 @@
-CREATE TABLE l2block (
-    block_id integer PRIMARY KEY,
-    new_root VARCHAR(256) NOT NULL,
-    witness jsonb NOT NULL,
-    created_time TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP
-);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,8 +2,8 @@
 #![allow(dead_code)]
 
 use crossbeam_channel::RecvTimeoutError;
+use fluidex_common::db::MIGRATOR;
 use rollup_state_manager::config::Settings;
-use rollup_state_manager::db::MIGRATOR;
 use rollup_state_manager::grpc::run_grpc_server;
 use rollup_state_manager::msg::{msg_loader, msg_processor};
 use rollup_state_manager::params;

--- a/src/bin/migrator.rs
+++ b/src/bin/migrator.rs
@@ -1,4 +1,4 @@
-use rollup_state_manager::db::{ConnectionType, MIGRATOR};
+use fluidex_common::db::{ConnectionType, MIGRATOR};
 use sqlx::Connection;
 
 #[tokio::main]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,0 @@
-pub type DbType = sqlx::Postgres;
-pub type ConnectionType = sqlx::postgres::PgConnection;
-pub type PoolOptions = sqlx::postgres::PgPoolOptions;
-pub type DBErrType = sqlx::Error;
-
-pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!(); // defaults to "./migrations"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 pub mod account;
 pub mod config;
 pub mod r#const;
-pub mod db;
 pub mod grpc;
 pub mod msg;
 pub mod params;


### PR DESCRIPTION
Part of issue #131 
Uses https://github.com/Fluidex/common-rs/pull/5 of `common-rs`

Replaces to use MIGRATOR of `common-rs`.