### PR TITLE
data avaliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=master#4483601613f34d281029d36a00756bb560ca5962"
+source = "git+https://github.com/fluidex/common-rs?branch=master#9b5a93bf54b757c23fc4c065711c300fd9c2cf6c"
 dependencies = [
  "babyjubjub-rs",
  "backtrace",

--- a/src/account.rs
+++ b/src/account.rs
@@ -335,8 +335,8 @@ fn sign_msg_with_signing_key(priv_key: &SigningKey, msg: &str) -> EthersSignatur
     let digest = Sha256Proxy::from(msg_hash);
     let recoverable_sig: RecoverableSignature = priv_key.sign_digest(digest);
 
-    //TODO: what if we want to use different CHAIN_ID for layer 1, but keep using 1 for layer 2?
-    let v = to_eip155_v(recoverable_sig.recovery_id(), *CHAIN_ID as u64);
+    //TODO: we should allow specifing chainID, here we just use ethereum mainnet's chainID
+    let v = to_eip155_v(recoverable_sig.recovery_id(), 1);
 
     let r_bytes: FieldBytes<Secp256k1> = recoverable_sig.r().into();
     let s_bytes: FieldBytes<Secp256k1> = recoverable_sig.s().into();

--- a/src/account.rs
+++ b/src/account.rs
@@ -335,8 +335,8 @@ fn sign_msg_with_signing_key(priv_key: &SigningKey, msg: &str) -> EthersSignatur
     let digest = Sha256Proxy::from(msg_hash);
     let recoverable_sig: RecoverableSignature = priv_key.sign_digest(digest);
 
-    //TODO: we should allow specifing chainID, here we just use ethereum mainnet's chainID
-    let v = to_eip155_v(recoverable_sig.recovery_id(), 1);
+    //TODO: what if we want to use different CHAIN_ID for layer 1, but keep using 1 for layer 2?
+    let v = to_eip155_v(recoverable_sig.recovery_id(), *CHAIN_ID as u64);
 
     let r_bytes: FieldBytes<Secp256k1> = recoverable_sig.r().into();
     let s_bytes: FieldBytes<Secp256k1> = recoverable_sig.s().into();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,11 +9,11 @@ static SETTINGS: OnceCell<Settings> = OnceCell::new();
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Settings {
-    brokers: String,
-    grpc_addr: String,
-    db: String,
-    persist_dir: Box<Path>,
-    persist_every_n_block: usize,
+    pub brokers: String,
+    pub grpc_addr: String,
+    pub db: String,
+    pub persist_dir: Box<Path>,
+    pub persist_every_n_block: usize,
 }
 
 impl Settings {
@@ -32,6 +32,16 @@ impl Settings {
             .unwrap();
 
         Self::set(conf.try_into().unwrap());
+    }
+
+    pub fn new() -> Self {
+        Settings {
+            brokers: String::new(),
+            grpc_addr: String::new(),
+            db: String::new(),
+            persist_dir: Box::from(Path::new(".")),
+            persist_every_n_block: 0,
+        }        
     }
 
     /// Sets the contents of this cell to the singleton `Settings`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,12 @@ pub struct Settings {
     pub persist_every_n_block: usize,
 }
 
+impl Default for Settings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Settings {
     /// Initializes with parsing config file in env var `CONFIG`.
     ///
@@ -41,7 +47,7 @@ impl Settings {
             db: String::new(),
             persist_dir: Box::from(Path::new(".")),
             persist_every_n_block: 0,
-        }        
+        }
     }
 
     /// Sets the contents of this cell to the singleton `Settings`

--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -139,6 +139,10 @@ impl GlobalState {
         Tree::print_config();
     }
 
+    pub fn balance_bits(&self) -> usize { self.balance_levels }
+    pub fn order_bits(&self) -> usize { self.order_levels }
+    pub fn account_bits(&self) -> usize { self.account_levels }
+
     pub fn new(balance_levels: usize, order_levels: usize, account_levels: usize, verbose: bool) -> Self {
         log::debug!(
             "create GlobalState account_levels {} balance_levels {} order_levels {}",

--- a/src/state/global.rs
+++ b/src/state/global.rs
@@ -139,9 +139,15 @@ impl GlobalState {
         Tree::print_config();
     }
 
-    pub fn balance_bits(&self) -> usize { self.balance_levels }
-    pub fn order_bits(&self) -> usize { self.order_levels }
-    pub fn account_bits(&self) -> usize { self.account_levels }
+    pub fn balance_bits(&self) -> usize {
+        self.balance_levels
+    }
+    pub fn order_bits(&self) -> usize {
+        self.order_levels
+    }
+    pub fn account_bits(&self) -> usize {
+        self.account_levels
+    }
 
     pub fn new(balance_levels: usize, order_levels: usize, account_levels: usize, verbose: bool) -> Self {
         log::debug!(

--- a/src/state/manager_wrapper.rs
+++ b/src/state/manager_wrapper.rs
@@ -128,7 +128,7 @@ impl ManagerWrapper {
         let detail = L2BlockDetail {
             old_root: *old_account_roots.first().unwrap(),
             new_root: *new_account_roots.last().unwrap(),
-            txdata_hash: encoder.encode_end(),
+            txdata_hash: encoder.finish(),
             txs_type,
             encoded_txs,
             balance_path_elements,

--- a/src/state/manager_wrapper.rs
+++ b/src/state/manager_wrapper.rs
@@ -9,6 +9,7 @@ use crate::r#const::sled_db::*;
 use crate::types::l2::{
     tx_detail_idx, DepositTx, FullSpotTradeTx, L2Block, L2BlockDetail, Order, RawTx, TransferTx, TxType, WithdrawTx, TX_LENGTH,
 };
+use ethers::core::types::U256;
 use crate::types::merkle_tree::Tree;
 use anyhow::{anyhow, bail};
 use fluidex_common::babyjubjub_rs::{self, Point};
@@ -114,6 +115,7 @@ impl ManagerWrapper {
         let detail = L2BlockDetail {
             old_root: *old_account_roots.first().unwrap(),
             new_root: *new_account_roots.last().unwrap(),
+            txdata_hash: U256::zero(),
             txs_type,
             encoded_txs,
             balance_path_elements,

--- a/src/state/manager_wrapper.rs
+++ b/src/state/manager_wrapper.rs
@@ -7,9 +7,8 @@ use crate::config::Settings;
 #[cfg(feature = "persist_sled")]
 use crate::r#const::sled_db::*;
 use crate::types::l2::{
-    tx_detail_idx, DepositTx, FullSpotTradeTx, L2Block, L2BlockDetail, Order, RawTx, TransferTx, TxType, WithdrawTx, TX_LENGTH,
+    tx_detail_idx, DepositTx, FullSpotTradeTx, L2Block, L2BlockDetail, Order, RawTx, TransferTx, TxType, WithdrawTx, TX_LENGTH, AmountType, TxDataEncoder,
 };
-use ethers::core::types::U256;
 use crate::types::merkle_tree::Tree;
 use anyhow::{anyhow, bail};
 use fluidex_common::babyjubjub_rs::{self, Point};
@@ -26,8 +25,13 @@ pub struct ManagerWrapper {
     buffered_txs: Vec<RawTx>,
     block_generate_num: usize,
     //buffered_blocks: Vec<L2Block>,
+    tx_data_encoder: TxDataEncoder,
     verbose: bool,
     verify_sig: bool,
+}
+
+fn encode_amount_to_fr(amount: &AmountType) -> anyhow::Result<Fr> {
+    Ok(Fr::from_bigint(amount.clone().to_encoded_int()?))
 }
 
 impl ManagerWrapper {
@@ -35,12 +39,19 @@ impl ManagerWrapper {
         Tree::print_config();
     }
     pub fn new(state: Arc<RwLock<GlobalState>>, n_tx: usize, block_offset: Option<usize>, verbose: bool) -> Self {
+
+        let tx_data_encoder = {
+            let st = state.read().unwrap();
+            TxDataEncoder::new(st.balance_bits() as u32, st.account_bits() as u32)
+        };
+
         Self {
             state,
             n_tx,
             buffered_txs: Vec::new(),
             block_generate_num: block_offset.unwrap_or(0),
             //buffered_blocks: Vec::new(),
+            tx_data_encoder,
             verbose,
             verify_sig: true,
         }
@@ -87,7 +98,7 @@ impl ManagerWrapper {
         self.mut_state().set_token_balance(account_id, token_id, balance);
     }
 
-    pub fn forge_with_txs(block_id: usize, buffered_txs: &[RawTx]) -> L2Block {
+    pub fn forge_with_txs(block_id: usize, buffered_txs: &[RawTx], encoder: &mut TxDataEncoder) -> L2Block {
         let txs_type = buffered_txs.iter().map(|tx| tx.tx_type).collect();
         let encoded_txs = buffered_txs.iter().map(|tx| tx.payload.clone()).collect();
         let balance_path_elements = buffered_txs
@@ -112,10 +123,12 @@ impl ManagerWrapper {
             .collect();
         let old_account_roots: Vec<Fr> = buffered_txs.iter().map(|tx| tx.root_before).collect();
         let new_account_roots: Vec<Fr> = buffered_txs.iter().map(|tx| tx.root_after).collect();
+        //calc tx-pubdata's hash
+        buffered_txs.iter().for_each(|tx| tx.encode_pubdata(encoder).unwrap());
         let detail = L2BlockDetail {
             old_root: *old_account_roots.first().unwrap(),
             new_root: *new_account_roots.last().unwrap(),
-            txdata_hash: U256::zero(),
+            txdata_hash: encoder.encode_end(),
             txs_type,
             encoded_txs,
             balance_path_elements,
@@ -152,7 +165,7 @@ impl ManagerWrapper {
         let nonce = acc.nonce;
 
         let mut encoded_tx = [Fr::zero(); TX_LENGTH];
-        encoded_tx[tx_detail_idx::AMOUNT] = tx.amount.to_fr();
+        encoded_tx[tx_detail_idx::AMOUNT] = encode_amount_to_fr(&tx.amount)?;
 
         encoded_tx[tx_detail_idx::TOKEN_ID1] = Fr::from_u32(tx.token_id);
         encoded_tx[tx_detail_idx::ACCOUNT_ID1] = Fr::from_u32(tx.account_id);
@@ -249,7 +262,7 @@ impl ManagerWrapper {
         encoded_tx[tx_detail_idx::ACCOUNT_ID2] = Fr::from_u32(tx.to);
         encoded_tx[tx_detail_idx::TOKEN_ID1] = Fr::from_u32(tx.token_id);
         encoded_tx[tx_detail_idx::TOKEN_ID2] = Fr::from_u32(tx.token_id);
-        encoded_tx[tx_detail_idx::AMOUNT] = tx.amount.to_fr();
+        encoded_tx[tx_detail_idx::AMOUNT] = encode_amount_to_fr(&tx.amount).unwrap();
 
         encoded_tx[tx_detail_idx::BALANCE1] = from_old_balance;
         encoded_tx[tx_detail_idx::NONCE1] = from_account.nonce;
@@ -342,7 +355,7 @@ impl ManagerWrapper {
         // first, generate the tx
         let mut encoded_tx = [Fr::zero(); TX_LENGTH];
 
-        encoded_tx[tx_detail_idx::AMOUNT] = tx.amount.to_fr();
+        encoded_tx[tx_detail_idx::AMOUNT] = encode_amount_to_fr(&tx.amount).unwrap();
 
         encoded_tx[tx_detail_idx::TOKEN_ID1] = Fr::from_u32(token_id);
         encoded_tx[tx_detail_idx::ACCOUNT_ID1] = Fr::from_u32(account_id);
@@ -493,8 +506,8 @@ impl ManagerWrapper {
         encoded_tx[tx_detail_idx::OLD_ORDER2_FILLED_BUY] = old_order2_in_tree.filled_buy;
         encoded_tx[tx_detail_idx::OLD_ORDER2_AMOUNT_BUY] = old_order2_in_tree.total_buy;
 
-        encoded_tx[tx_detail_idx::AMOUNT] = trade.amount_1to2.to_fr();
-        encoded_tx[tx_detail_idx::AMOUNT2] = trade.amount_2to1.to_fr();
+        encoded_tx[tx_detail_idx::AMOUNT] = encode_amount_to_fr(&trade.amount_1to2).unwrap();
+        encoded_tx[tx_detail_idx::AMOUNT2] = encode_amount_to_fr(&trade.amount_2to1).unwrap();
         encoded_tx[tx_detail_idx::ORDER1_POS] = Fr::from_u32(order1_pos);
         encoded_tx[tx_detail_idx::ORDER2_POS] = Fr::from_u32(order2_pos);
 
@@ -649,7 +662,7 @@ impl ManagerWrapper {
         let mut i = 0;
         let len = self.buffered_txs.len();
         while i + self.n_tx <= len {
-            let block = Self::forge_with_txs(self.block_generate_num, &self.buffered_txs[i..i + self.n_tx]);
+            let block = Self::forge_with_txs(self.block_generate_num, &self.buffered_txs[i..i + self.n_tx], &mut self.tx_data_encoder);
             blocks.push(block);
 
             self.block_generate_num += 1;
@@ -706,4 +719,69 @@ impl ManagerWrapper {
     fn mut_state(&self) -> RwLockWriteGuard<'_, GlobalState> {
         self.state.write().unwrap()
     }
+}
+
+#[cfg(test)]
+mod test {
+
+    use fluidex_common::rust_decimal::Decimal;
+    //use crate::account::Signature;
+    use super::*;
+    use crate::types::l2::L2Key;
+    use crate::config::Settings;
+
+    fn dummy_l2key() -> L2Key {
+        L2Key {
+            eth_addr: Fr::zero(),
+            sign: Fr::zero(),
+            ay: Fr::zero(),
+        }
+    }
+
+    #[test]
+    fn test_state_pubdata() {
+
+        let mut s = Settings::new();
+        //don't persist
+        s.persist_every_n_block = 1000;
+        Settings::set(s);
+
+        let gs = GlobalState::new(2,3,2,false);
+        let mut wrapper = ManagerWrapper::new(Arc::new(RwLock::new(gs)), 2, None, false);
+
+        //notice offset is of no use if we do not persist tx locally ...
+        //testing example picked from circuit/test/testdata/msg_float.jsonl
+        //block 1
+        wrapper.deposit(DepositTx {
+            account_id: 0,
+            token_id: 1,
+            amount: AmountType::from_decimal(&Decimal::new(1000000i64, 0), 6).unwrap(),
+            l2key: Some(dummy_l2key()),
+        }, None).unwrap();
+        wrapper.deposit(DepositTx {
+            account_id: 0,
+            token_id: 0,
+            amount: AmountType::from_decimal(&Decimal::new(1000000i64, 0), 6).unwrap(),
+            l2key: Some(dummy_l2key()),
+        }, None).unwrap();
+
+        //block 2
+        wrapper.deposit(DepositTx {
+            account_id: 1,
+            token_id: 1,
+            amount: AmountType::from_decimal(&Decimal::new(1000000i64, 0), 6).unwrap(),
+            l2key: Some(dummy_l2key()),
+        }, None).unwrap();
+        wrapper.deposit(DepositTx {
+            account_id: 1,
+            token_id: 0,
+            amount: AmountType::from_decimal(&Decimal::new(1000000i64, 0), 6).unwrap(),
+            l2key: Some(dummy_l2key()),
+        }, None).unwrap();
+
+        let blks = wrapper.pop_all_blocks();
+        assert_eq!(blks[0].detail.txdata_hash.low_u128(), 298571517759234780085007816947765249360u128);
+        assert_eq!(blks[1].detail.txdata_hash.low_u128(), 296940437820416654432875895781101051776u128);
+    }
+
 }

--- a/src/types/l2/block.rs
+++ b/src/types/l2/block.rs
@@ -1,12 +1,14 @@
 use super::tx::TxType;
 use crate::types::merkle_tree::MerklePath;
 
+use ethers::core::types::U256;
 use fluidex_common::Fr;
 
 #[derive(Clone)]
 pub struct L2BlockDetail {
     pub old_root: Fr,
     pub new_root: Fr,
+    pub txdata_hash: U256,
     pub txs_type: Vec<TxType>,
     pub encoded_txs: Vec<Vec<Fr>>,
     pub balance_path_elements: Vec<[MerklePath; 4]>,

--- a/src/types/l2/serialize.rs
+++ b/src/types/l2/serialize.rs
@@ -212,6 +212,10 @@ pub struct L2BlockSerde {
     pub old_root: FrStr,
     #[serde(rename = "newRoot")]
     pub new_root: FrStr,
+    #[serde(rename = "txDataHashHi")]
+    pub txdata_hash_hi: u128,
+    #[serde(rename = "txDataHashLo")]
+    pub txdata_hash_lo: u128,
     #[serde(rename = "txsType")]
     pub txs_type: Vec<l2::TxType>,
     #[serde(rename = "encodedTxs")]
@@ -252,6 +256,8 @@ impl From<l2::L2BlockDetail> for L2BlockSerde {
         L2BlockSerde {
             old_root: origin.old_root.into(),
             new_root: origin.new_root.into(),
+            txdata_hash_lo: origin.txdata_hash.low_u128(),
+            txdata_hash_hi: (origin.txdata_hash >> 128u8).low_u128(),
             txs_type: origin.txs_type,
             encoded_txs: origin
                 .encoded_txs

--- a/src/types/l2/serialize.rs
+++ b/src/types/l2/serialize.rs
@@ -257,7 +257,9 @@ impl From<l2::L2BlockDetail> for L2BlockSerde {
             old_root: origin.old_root.into(),
             new_root: origin.new_root.into(),
             txdata_hash_lo: Fr::from_slice(&origin.txdata_hash.low_u128().to_be_bytes()).unwrap().into(),
-            txdata_hash_hi: Fr::from_slice(&(origin.txdata_hash >> 128u8).low_u128().to_be_bytes()).unwrap().into(),
+            txdata_hash_hi: Fr::from_slice(&(origin.txdata_hash >> 128u8).low_u128().to_be_bytes())
+                .unwrap()
+                .into(),
             txs_type: origin.txs_type,
             encoded_txs: origin
                 .encoded_txs

--- a/src/types/l2/serialize.rs
+++ b/src/types/l2/serialize.rs
@@ -213,9 +213,9 @@ pub struct L2BlockSerde {
     #[serde(rename = "newRoot")]
     pub new_root: FrStr,
     #[serde(rename = "txDataHashHi")]
-    pub txdata_hash_hi: u128,
+    pub txdata_hash_hi: FrStr,
     #[serde(rename = "txDataHashLo")]
-    pub txdata_hash_lo: u128,
+    pub txdata_hash_lo: FrStr,
     #[serde(rename = "txsType")]
     pub txs_type: Vec<l2::TxType>,
     #[serde(rename = "encodedTxs")]
@@ -256,8 +256,8 @@ impl From<l2::L2BlockDetail> for L2BlockSerde {
         L2BlockSerde {
             old_root: origin.old_root.into(),
             new_root: origin.new_root.into(),
-            txdata_hash_lo: origin.txdata_hash.low_u128(),
-            txdata_hash_hi: (origin.txdata_hash >> 128u8).low_u128(),
+            txdata_hash_lo: Fr::from_slice(&origin.txdata_hash.low_u128().to_be_bytes()).unwrap().into(),
+            txdata_hash_hi: Fr::from_slice(&(origin.txdata_hash >> 128u8).low_u128().to_be_bytes()).unwrap().into(),
             txs_type: origin.txs_type,
             encoded_txs: origin
                 .encoded_txs

--- a/src/types/l2/tx.rs
+++ b/src/types/l2/tx.rs
@@ -297,7 +297,7 @@ impl TxDataEncoder {
     }
 
     //finish encoding, output the result hash, and prepare for next encoding
-    pub fn encode_end(&mut self) -> U256 {
+    pub fn finish(&mut self) -> U256 {
         let encoded_bytes = self.ctx.replace(BitEncodeContext::new()).unwrap().seal();
         //        println!("{:x?}", &encoded_bytes);
         U256::from_big_endian(&sha2::Sha256::digest(&encoded_bytes))
@@ -438,7 +438,7 @@ fn test_tx_pubdata() {
     tx_nop.encode_pubdata(&mut tx_encoder).unwrap();
     tx_nop.encode_pubdata(&mut tx_encoder).unwrap();
 
-    let hash = tx_encoder.encode_end();
+    let hash = tx_encoder.finish();
     //preimage should be: 4af0b5a4000025477400000013a1dd00000000000000000000000000000000
     assert_eq!(hash.low_u128(), 273971448787759175191113939742247265668u128);
 }

--- a/src/types/l2/tx.rs
+++ b/src/types/l2/tx.rs
@@ -1,12 +1,16 @@
 use super::order;
+use super::{tx_detail_idx};
 use crate::account::Signature;
 use crate::types::merkle_tree::MerklePath;
-use anyhow::bail;
+use anyhow::{anyhow};
 use anyhow::Result;
 use fluidex_common::ff::Field;
-use fluidex_common::types::{Float864, Float40, FrExt};
+use fluidex_common::types::{Float40, FrExt};
 use fluidex_common::Fr;
-use std::convert::TryInto;
+use fluidex_common::num_bigint::BigInt;
+use num::{Zero, One, PrimInt, ToPrimitive};
+use ethers::core::types::{U256};
+use sha2::Digest;
 
 #[derive(Copy, Clone)]
 #[repr(u8)]
@@ -54,6 +58,11 @@ pub enum L2Tx {
     Transfer(TransferTx),
     FullSpotTrade(FullSpotTradeTx),
     Withdraw(WithdrawTx),
+}
+
+#[derive(Debug)]
+pub struct NopTx {
+
 }
 
 #[derive(Debug)]
@@ -174,80 +183,183 @@ impl WithdrawTx {
     }
 }
 
-// DepositToNew 1 + 4 + 2 + 9 + 32 + 1 + 32 = 81
-pub const PUBDATA_LEN: usize = 81;
-pub const ACCOUNT_ID_LEN: usize = 4;
-pub const TOKEN_ID_LEN: usize = 2;
-pub const AMOUNT_LEN: usize = 9;
-pub const FR_LEN: usize = 32;
-//pub type PUBDATA = [u8; PUBDATA_LEN];
-
 // https://github.com/fluidex/circuits/issues/144
-impl DepositTx {
-    pub fn to_pubdata(&self) -> Vec<u8> {
-        let mut result = vec![TxType::Deposit as u8];
-        result.append(&mut self.account_id.to_be_bytes().to_vec());
-        result.append(&mut (self.token_id as u16).to_be_bytes().to_vec());
-        result.append(&mut self.amount.encode());
-        let l2key = self.l2key.clone().unwrap_or_default();
-        result.append(&mut (l2key.ay.to_vec_be()));
-        result.append(&mut [l2key.sign.to_bool().unwrap() as u8].to_vec());
-        result.append(&mut (l2key.eth_addr.to_vec_be()));
-        //println!("{}, {}", result.len(), PUBDATA_LEN);
-        assert!(result.len() <= PUBDATA_LEN);
-        result.append(&mut vec![0; PUBDATA_LEN - result.len()]);
-        result
+// https://github.com/fluidex/circuits/pull/181
+struct BitEncodeContext {
+    encoding_buf: Vec<u8>,
+    applying_bit: usize,
+    encoding_char: u8,
+}
+
+impl BitEncodeContext {
+
+    pub fn new() -> Self{
+        BitEncodeContext {
+            encoding_buf: Vec::new(),
+            applying_bit: 0,
+            encoding_char: 0,
+        }
     }
-    pub fn from_pubdata(data: &[u8]) -> Result<Self> {
-        if data.len() != PUBDATA_LEN {
-            bail!("invalid len for DepositTx");
+
+    fn next_byte(&mut self) {
+        assert_eq!(self.applying_bit, 8);
+        self.encoding_buf.push(self.encoding_char);
+        self.applying_bit = 0;
+        self.encoding_char = 0u8;
+    }
+
+    fn apply_bit(&mut self, is_zero: bool) {
+        let mask = [128, 64, 32, 16, 8, 4, 2, 1];
+        
+        if !is_zero {
+            self.encoding_char += mask[self.applying_bit];
         }
-        let mut idx: usize = 0;
+        self.applying_bit += 1;
 
-        if data[0] != TxType::Deposit as u8 {
-            bail!("invalid type for DepositTx");
+        if self.applying_bit == 8 {
+            self.next_byte();
         }
-        idx += 1;
+    }
 
-        let account_id = u32::from_be_bytes(data[idx..(idx + ACCOUNT_ID_LEN)].try_into()?);
-        idx += ACCOUNT_ID_LEN;
+    fn seal(mut self) -> Vec<u8> {
+        self.encoding_buf.push(self.encoding_char);
+        self.encoding_buf
+    }
 
-        let token_id = (u16::from_be_bytes(data[idx..(idx + TOKEN_ID_LEN)].try_into()?)) as u32;
-        idx += TOKEN_ID_LEN;
+    fn encode_primint<T: PrimInt + Zero + One>(&mut self, n: T, bits: u32) -> Result<()>{
+        let mut n = n;
+        let mut i = bits;
 
-        //TODO: temporary compatible to pubdata using float864 encoding
-        let wide_float = Float864::decode(&data[idx..(idx + AMOUNT_LEN)])?;
-        let amount = AmountType::from_decimal(&wide_float.to_decimal(0), 0)?;
-        idx += AMOUNT_LEN;
-
-        let ay = Fr::from_slice(&data[idx..(idx + FR_LEN)])?;
-        idx += FR_LEN;
-        if ay.is_zero() {
-            return Ok(Self {
-                account_id,
-                token_id,
-                amount,
-                l2key: None,
-            });
-        }
-
-        let sign = Fr::from_slice(&data[idx..(idx + 1)])?;
-        idx += 1;
-        if sign != Fr::one() && sign != Fr::zero() {
-            bail!("invalid l2 account sign");
+        while i > 0 {
+            self.apply_bit((n & T::one()) == T::zero());
+            n = n.unsigned_shr(1);
+            i -= 1;
         }
 
-        let eth_addr = Fr::from_slice(&data[idx..(idx + FR_LEN)])?;
-        //idx += FR_LEN;
+        if n != T::zero() {
+            Err(anyhow!("can not encode number within specified bits"))
+        }else {
+            Ok(())
+        }
+    }
 
-        Ok(Self {
-            account_id,
-            token_id,
-            amount,
-            l2key: Some(L2Key { eth_addr, sign, ay }),
-        })
+    fn encode_bytes(&mut self, bts: &[u8]) {
+        for ch in bts {
+          self.encode_primint(*ch, 8).unwrap();
+        }
+    }
+
+    fn encode_str(&mut self, s: &str) {
+        self.encode_bytes(s.as_bytes())
+    }    
+}
+
+pub const AMOUNT_LEN: u32 = 5;
+
+pub struct TxDataEncoder {
+    ctx: BitEncodeContext,
+    pub account_bits: u32,
+    pub token_bits: u32,
+}
+
+impl TxDataEncoder {
+
+    pub fn new(balance_levels: u32, account_levels: u32) -> Self {
+        TxDataEncoder {
+            ctx: BitEncodeContext::new(),
+            account_bits: account_levels,
+            token_bits: balance_levels,
+        }
+    }
+
+    pub fn pubdata_len_bits(&self) -> u32 {
+        self.account_bits + self.token_bits + AMOUNT_LEN * 8
+    }
+
+    pub fn encode_account(&mut self, account_id: u32) -> Result<()> {
+        self.ctx.encode_primint(account_id, self.account_bits)
+    }
+
+    pub fn encode_token(&mut self, token_id: u32) -> Result<()> {
+        self.ctx.encode_primint(token_id, self.token_bits)
+    }
+
+    pub fn encode_amount(&mut self, amount: &AmountType) -> Result<()> {
+        let encoded_big = amount.to_encoded_int()?;
+        assert_eq!(AMOUNT_LEN, AmountType::encode_len() as u32);
+        self.ctx.encode_primint(encoded_big.to_u128().unwrap(), AMOUNT_LEN * 8)
+    }
+
+    pub fn encode_fr(&mut self, fr: &Fr, bits: u32) -> Result<()> {
+        self.ctx.encode_primint(fr.to_i64(), bits)
+    }
+
+    pub fn to_hash(self) -> U256{
+        let encoded_bytes = self.ctx.seal();
+        println!("{:x?}", &encoded_bytes);
+        U256::from_big_endian(&sha2::Sha256::digest(&encoded_bytes))
+    }
+    
+}
+
+impl RawTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        let payload = &self.payload;
+        encoder.encode_fr(&payload[tx_detail_idx::ACCOUNT_ID1], encoder.account_bits)?;
+        encoder.encode_fr(&payload[tx_detail_idx::ACCOUNT_ID2], encoder.account_bits)?;
+        encoder.encode_fr(&payload[tx_detail_idx::TOKEN_ID1], encoder.token_bits)?;
+        encoder.encode_fr(&payload[tx_detail_idx::AMOUNT], AMOUNT_LEN*8)?;
+        Ok(())
     }
 }
+
+impl NopTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        encoder.encode_account(0)?;
+        encoder.encode_account(0)?;
+        encoder.encode_token(0)?;
+        encoder.encode_amount(&AmountType::from_encoded_bigint(BigInt::from(0)).unwrap())
+    }    
+}
+
+impl DepositTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        encoder.encode_account(self.account_id)?;
+        encoder.encode_account(self.account_id)?;
+        encoder.encode_token(self.token_id)?;
+        encoder.encode_amount(&self.amount)
+    }
+}
+
+impl TransferTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        encoder.encode_account(self.from)?;
+        encoder.encode_account(self.to)?;
+        encoder.encode_token(self.token_id)?;
+        encoder.encode_amount(&self.amount)
+    }
+}
+
+impl SpotTradeTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        //TODO: spot trade is not completely encoded yet
+        encoder.encode_account(self.order1_account_id)?;
+        encoder.encode_account(self.order2_account_id)?;
+        encoder.encode_token(self.token_id_1to2)?;
+        encoder.encode_amount(&self.amount_1to2)
+    }
+}
+
+impl WithdrawTx {
+    pub fn encode_pubdata(&self, encoder: &mut TxDataEncoder) -> Result<()> {
+        //TODO: should we encode amount as minus?
+        encoder.encode_account(self.account_id)?;
+        encoder.encode_account(self.account_id)?;
+        encoder.encode_token(self.token_id)?;
+        encoder.encode_amount(&self.amount)
+    }
+}
+
 /*
 impl DepositToOldTx {
     pub fn to_pubdata(&self) -> Vec<u8> {
@@ -287,25 +399,49 @@ impl DepositToOldTx {
 */
 #[cfg(test)]
 #[test]
-fn test_deposit_to_old_pubdata() {
-    let tx = DepositTx {
-        account_id: 1323,
-        token_id: 232,
-        amount: AmountType {
-            significand: 756,
-            exponent: 11,
-        },
+fn test_tx_pubdata() {
+
+    let mut tx_encoder = TxDataEncoder::new(3, 3);
+
+    let tx1 = DepositTx {
+        account_id: 2,
+        token_id: 5,
+        amount: AmountType::from_encoded_bigint(BigInt::from(1234567)).unwrap(),
         l2key: None,
     };
-    let pubdata1 = tx.to_pubdata();
-    println!("pubdata {:?}", pubdata1);
-    let tx2 = DepositTx::from_pubdata(&pubdata1).unwrap();
-    assert_eq!(tx.account_id, tx2.account_id);
-    assert_eq!(tx.token_id, tx2.token_id);
-    assert_eq!(tx.amount.to_bigint(), tx2.amount.to_bigint());
-    assert!(tx2.l2key.is_none());
-}
 
+    tx1.encode_pubdata(&mut tx_encoder).unwrap();
+
+    let tx2 = DepositTx {
+        account_id: 2,
+        token_id: 5,
+        amount: AmountType::from_encoded_bigint(BigInt::from(3000)).unwrap(),
+        l2key: None,
+    };
+
+    tx2.encode_pubdata(&mut tx_encoder).unwrap();
+
+    let tx3 = TransferTx {
+        from: 2,
+        to: 6,
+        token_id: 5,
+        amount: AmountType::from_encoded_bigint(BigInt::from(6000)).unwrap(),
+        l2key: None,
+        from_nonce: Fr::zero(),
+        sig: Signature::default(),
+    };
+
+    tx3.encode_pubdata(&mut tx_encoder).unwrap();
+    
+    let tx_nop = NopTx{};
+    tx_nop.encode_pubdata(&mut tx_encoder).unwrap();
+    tx_nop.encode_pubdata(&mut tx_encoder).unwrap();
+
+    let hash = tx_encoder.to_hash();
+    //preimage should be: 4af0b5a4000025477400000013a1dd00000000000000000000000000000000
+    assert_eq!(hash.low_u128(), 273971448787759175191113939742247265668u128);
+}
+/*
 #[cfg(test)]
 #[test]
 fn test_deposit_to_new_pubdata() {
@@ -330,3 +466,4 @@ fn test_deposit_to_new_pubdata() {
     assert_eq!(tx.amount.to_bigint(), tx2.amount.to_bigint());
     assert_eq!(tx.l2key.unwrap(), tx2.l2key.unwrap());
 }
+*/

--- a/src/types/l2/tx.rs
+++ b/src/types/l2/tx.rs
@@ -4,7 +4,7 @@ use crate::types::merkle_tree::MerklePath;
 use anyhow::bail;
 use anyhow::Result;
 use fluidex_common::ff::Field;
-use fluidex_common::types::{Float864, FrExt};
+use fluidex_common::types::{Float864, Float40, FrExt};
 use fluidex_common::Fr;
 use std::convert::TryInto;
 
@@ -38,7 +38,9 @@ pub struct RawTx {
     // debug info
     // extra: any;
 }
-pub type AmountType = Float864;
+
+pub type AmountType = Float40;
+
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct L2Key {
@@ -213,7 +215,9 @@ impl DepositTx {
         let token_id = (u16::from_be_bytes(data[idx..(idx + TOKEN_ID_LEN)].try_into()?)) as u32;
         idx += TOKEN_ID_LEN;
 
-        let amount = AmountType::decode(&data[idx..(idx + AMOUNT_LEN)])?;
+        //TODO: temporary compatible to pubdata using float864 encoding
+        let wide_float = Float864::decode(&data[idx..(idx + AMOUNT_LEN)])?;
+        let amount = AmountType::from_decimal(&wide_float.to_decimal(0), 0)?;
         idx += AMOUNT_LEN;
 
         let ay = Fr::from_slice(&data[idx..(idx + FR_LEN)])?;

--- a/tests/circuit_tests/test_l2_block.rs
+++ b/tests/circuit_tests/test_l2_block.rs
@@ -5,7 +5,7 @@ use rollup_state_manager::account::Account;
 use rollup_state_manager::state::{GlobalState, ManagerWrapper};
 use rollup_state_manager::test_utils::circuit::{CircuitSource, CircuitTestCase, CircuitTestData};
 use rollup_state_manager::test_utils::types::prec_token_id;
-use rollup_state_manager::types::l2::{self, DepositTx, L2BlockSerde, L2Key, OrderInput, SpotTradeTx, TransferTx, WithdrawTx};
+use rollup_state_manager::types::l2::{self, AmountType, DepositTx, L2BlockSerde, L2Key, OrderInput, SpotTradeTx, TransferTx, WithdrawTx};
 use serde_json::json;
 
 use rollup_state_manager::params;
@@ -88,7 +88,7 @@ impl Block {
                 DepositTx {
                     token_id: token_id0,
                     account_id: account_id0,
-                    amount: Decimal::new(300, 0).to_amount(prec_token_id(token_id0)),
+                    amount: AmountType::from_decimal(&Decimal::new(300, 0), prec_token_id(token_id0)).unwrap(),
                     l2key: None,
                 },
                 None,
@@ -99,7 +99,7 @@ impl Block {
             account_id0,
             account_id1,
             token_id0,
-            Decimal::new(100, 0).to_amount(prec_token_id(token_id0)),
+            AmountType::from_decimal(&Decimal::new(100, 0), prec_token_id(token_id0)).unwrap(),
         );
         transfer_tx0.l2key = Some(L2Key {
             eth_addr: account1.eth_addr(),
@@ -115,7 +115,7 @@ impl Block {
             account_id1,
             account_id0,
             token_id0,
-            Decimal::new(50, 0).to_amount(prec_token_id(token_id0)),
+            AmountType::from_decimal(&Decimal::new(50, 0), prec_token_id(token_id0)).unwrap(),
         );
         transfer_tx1.from_nonce = manager.get_account_nonce(account_id1);
         let hash = transfer_tx1.hash();
@@ -125,7 +125,7 @@ impl Block {
         let mut withdraw_tx = WithdrawTx::new(
             account_id0,
             token_id0,
-            Decimal::new(150, 0).to_amount(prec_token_id(token_id0)),
+            AmountType::from_decimal(&Decimal::new(150, 0), prec_token_id(token_id0)).unwrap(),
             manager.get_token_balance(account_id0, token_id0),
         );
         manager.fill_withdraw_tx(&mut withdraw_tx);
@@ -142,7 +142,7 @@ impl Block {
                 DepositTx {
                     account_id: account_id1,
                     token_id: token_id0,
-                    amount: Decimal::new(199, 0).to_amount(prec_token_id(token_id0)),
+                    amount: AmountType::from_decimal(&Decimal::new(199, 0), prec_token_id(token_id0)).unwrap(),
                     l2key: None,
                 },
                 None,
@@ -153,7 +153,7 @@ impl Block {
                 DepositTx {
                     account_id: account_id2,
                     token_id: token_id1,
-                    amount: Decimal::new(1990, 0).to_amount(prec_token_id(token_id1)),
+                    amount: AmountType::from_decimal(&Decimal::new(1990, 0), prec_token_id(token_id1)).unwrap(),
                     l2key: Some(L2Key {
                         eth_addr: account2.eth_addr(),
                         sign: account2.sign(),
@@ -201,8 +201,8 @@ impl Block {
             order2_account_id: account_id2,
             token_id_1to2: token_id0,
             token_id_2to1: token_id1,
-            amount_1to2: Decimal::new(amount_1to2, 0).to_amount(prec_token_id(token_id0)),
-            amount_2to1: Decimal::new(amount_2to1, 0).to_amount(prec_token_id(token_id1)),
+            amount_1to2: AmountType::from_decimal(&Decimal::new(amount_1to2, 0), prec_token_id(token_id0)).unwrap(),
+            amount_2to1: AmountType::from_decimal(&Decimal::new(amount_2to1, 0), prec_token_id(token_id1)).unwrap(),
             order1_id: order_id1,
             order2_id: order_id2,
         };

--- a/tests/global_state/bench.rs
+++ b/tests/global_state/bench.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 #[cfg(test)]
+#[cfg(not(feature = "windows_build"))]
 use {pprof::protos::Message, std::io::Write};
 
 fn bench_with_dummy_transfers() -> Result<()> {
@@ -218,6 +219,7 @@ fn run_bench() -> Result<()> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "windows_build"))]
 fn profile_bench() {
     let guard = pprof::ProfilerGuard::new(100).unwrap();
 

--- a/tests/global_state/bench.rs
+++ b/tests/global_state/bench.rs
@@ -2,7 +2,7 @@
 #![allow(unreachable_patterns)]
 use anyhow::Result;
 use fluidex_common::rust_decimal_macros::dec;
-use fluidex_common::types::{Decimal, Float864};
+use fluidex_common::types::{Decimal, Float40};
 use rollup_state_manager::account::Account;
 use rollup_state_manager::msg::msg_processor;
 use rollup_state_manager::params;
@@ -70,7 +70,7 @@ fn bench_with_dummy_transfers() -> Result<()> {
     processor.handle_deposit_msg(&mut manager, deposit.into());
 
     // step3: bench transfer
-    let amount = Float864::from_decimal(&dec!(1), prec_token_id(0)).unwrap();
+    let amount = Float40::from_decimal(&dec!(1), prec_token_id(0)).unwrap();
     let mut transfer = TransferTx::new(1, 2, 0 /*ETH*/, amount);
     let transfer_hash = transfer.hash();
     let sig = user1.sign_hash(transfer_hash).unwrap();


### PR DESCRIPTION
This PR induce the data avaliability feature required by #178 with:

- [x] Porting all encoding implements from the js proto inside [circuits](https://github.com/fluidex/circuits)
- [x] The exported input data now include hash of the pub (on-chain) tx data
- [x] Unittests
- [x] Integration tests in backend