### PR TITLE
Write pubdata into db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cbf586c80ada5e5ccdecae80d3ef0854f224e2dd74435f8d87e6831b8d0a38"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -982,11 +982,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "Inflector",
  "anyhow",
- "cargo_metadata",
  "cfg-if",
  "ethers-core",
  "getrandom",
@@ -1004,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1018,10 +1017,11 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
+ "cargo_metadata",
  "convert_case",
  "ecdsa",
  "elliptic-curve",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#6bf45a0b5d320809366d2aedfcda68b957e9fc2e"
+source = "git+https://github.com/gakonst/ethers-rs#203b2e8ea303f36111968f8a143a03e50ecb98b2"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1194,7 +1194,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=master#656ef50fc63c025efe2c40298467b595be7f895a"
+source = "git+https://github.com/fluidex/common-rs?branch=master#769e979cf6efef9b157b3b00873e2d5ed4c94d5b"
 dependencies = [
  "anyhow",
  "babyjubjub-rs",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -226,12 +226,13 @@ async fn save_block_to_db(pool: &PgPool, block: &L2Block) -> anyhow::Result<()> 
     let new_root = block.detail.new_root.to_hex_string();
     let detail = L2BlockSerde::from(block.detail.clone());
     sqlx::query(&format!(
-        "insert into {} (block_id, new_root, detail) values ($1, $2, $3)",
+        "insert into {} (block_id, new_root, detail, raw_public_data) values ($1, $2, $3, $4)",
         tablenames::L2_BLOCK
     ))
     .bind(block.block_id as u32)
     .bind(new_root)
     .bind(sqlx::types::Json(detail))
+    .bind(&block.public_data)
     .execute(pool)
     .await?;
 

--- a/src/grpc/controller.rs
+++ b/src/grpc/controller.rs
@@ -266,7 +266,7 @@ async fn get_l2_blocks(
 
     let limit = min(100, limit);
     let blocks_query = format!(
-        "select block_id, new_root, status, l1_tx_hash, detail, created_time
+        "select block_id, new_root, raw_public_data, status, l1_tx_hash, detail, created_time
             from {}
             where block_id <= $1
             order by block_id desc limit {}",
@@ -285,7 +285,7 @@ async fn get_l2_blocks(
 
 async fn get_l2_block_by_id(db_pool: &sqlx::Pool<DbType>, block_id: i64) -> Result<l2_block::L2Block, Status> {
     let stmt = format!(
-        "select block_id, new_root, status, l1_tx_hash, detail, created_time
+        "select block_id, new_root, raw_public_data, status, l1_tx_hash, detail, created_time
         from {}
         where block_id = $1
         order by created_time desc limit 1",

--- a/src/state/manager_wrapper.rs
+++ b/src/state/manager_wrapper.rs
@@ -242,10 +242,11 @@ impl ManagerWrapper {
         let new_account_roots: Vec<Fr> = buffered_txs.iter().map(|tx| tx.root_after).collect();
         //calc tx-pubdata's hash
         buffered_txs.iter().for_each(|tx| encode_rawtx_to_pubdata(tx, encoder).unwrap());
+        let (txdata_hash, public_data) = encoder.finish_with_raw();
         let detail = L2BlockDetail {
             old_root: *old_account_roots.first().unwrap(),
             new_root: *new_account_roots.last().unwrap(),
-            txdata_hash: encoder.finish(),
+            txdata_hash,
             txs_type,
             encoded_txs,
             balance_path_elements,
@@ -255,7 +256,11 @@ impl ManagerWrapper {
             old_account_roots,
             new_account_roots,
         };
-        L2Block { block_id, detail }
+        L2Block {
+            block_id,
+            detail,
+            public_data,
+        }
     }
     pub fn has_raw_tx(&self) -> bool {
         !self.buffered_txs.is_empty()

--- a/src/types/l2/block.rs
+++ b/src/types/l2/block.rs
@@ -23,4 +23,5 @@ pub struct L2BlockDetail {
 pub struct L2Block {
     pub block_id: usize,
     pub detail: L2BlockDetail,
+    pub public_data: Vec<u8>,
 }

--- a/src/types/l2/tx.rs
+++ b/src/types/l2/tx.rs
@@ -380,9 +380,15 @@ impl TxDataEncoder {
 
     //finish encoding, output the result hash, and prepare for next encoding
     pub fn finish(&mut self) -> U256 {
-        let encoded_bytes = self.ctx.replace(BitEncodeContext::new()).unwrap().seal();
+        let (hash, _) = self.finish_with_raw();
         //        println!("{:02x?}", &encoded_bytes);
-        U256::from_big_endian(&sha2::Sha256::digest(&encoded_bytes))
+        hash
+    }
+
+    pub fn finish_with_raw(&mut self) -> (U256, Vec<u8>) {
+        let encoded_bytes = self.ctx.replace(BitEncodeContext::new()).unwrap().seal();
+        let hash = U256::from_big_endian(&sha2::Sha256::digest(&encoded_bytes));
+        (hash, encoded_bytes)
     }
 }
 


### PR DESCRIPTION
Part of works for really inducing data availability into backend, they include:

- [x] Written public data to db for submitting on L1 contract (this PR)
- [ ] Contract accept public data, calculate the hash and used it as part of the public inputs for verifying block (in contract.demo)
- [ ] Submit block with public data to contract (in regnbue-bridge)

This PR update fluidex-common to latest and fill public-data col in db. Notice there is a breaking change in migration data so the schema for rollup-db has not been compatible with earlier version's. 