### PR TITLE
Support deposit for L1 contract

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 RUN_MODE=development # development or staging
 RUST_BACKTRACE=1
 RUST_LOG=rollup_state_manager=debug,info
+CIRCUIT_VER=197
 
 NTXS=2
 BALANCELEVELS=3

--- a/.github/workflows/global-state-test.yaml
+++ b/.github/workflows/global-state-test.yaml
@@ -92,6 +92,12 @@ jobs:
           cd circuits
           npm ci
 
+      - name: circuit version check
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin version_check
+
       - name: Test global_state
         run: bash tests/global_state/test.sh
 

--- a/.github/workflows/global-state-test.yaml
+++ b/.github/workflows/global-state-test.yaml
@@ -96,7 +96,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --bin version_check
+          args: --bin version_check --features version_check
 
       - name: Test global_state
         run: bash tests/global_state/test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c20e9df4a2d4a5adad5b47e17d76dac3e824346b181931c3ec9f7a85687b1"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2839,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "normpath",
  "num",
  "once_cell",
  "orchestra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
+name = "const-oid"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +735,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +800,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 dependencies = [
- "const-oid",
+ "const-oid 0.6.0",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.0",
 ]
 
 [[package]]
@@ -846,8 +873,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
- "der",
- "elliptic-curve",
+ "der 0.4.0",
+ "elliptic-curve 0.10.6",
  "hmac 0.11.0",
  "signature",
 ]
@@ -864,11 +891,25 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.6",
  "ff",
  "generic-array 0.14.4",
  "group",
  "pkcs8",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73d21281779c2c22cade2a4ab34eee34271869942546a364f7d552d30c62434"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "der 0.5.1",
+ "generic-array 0.14.4",
  "rand_core",
  "subtle",
  "zeroize",
@@ -950,11 +991,12 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "ethers-contract",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
@@ -963,8 +1005,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -981,8 +1023,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1002,8 +1044,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1016,15 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.5.5"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
  "cargo_metadata",
  "convert_case",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "ethabi",
  "generic-array 0.14.4",
  "hex",
@@ -1043,20 +1085,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-etherscan"
+version = "0.2.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
+dependencies = [
+ "ethers-core",
+ "reqwest",
+ "serde 1.0.130",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "ethers-middleware"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "async-trait",
  "ethers-contract",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
  "futures-util",
  "instant",
  "reqwest",
  "serde 1.0.130",
- "serde-aux",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1067,8 +1122,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1096,13 +1151,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "eth-keystore",
  "ethers-core",
  "futures-executor",
@@ -1117,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+source = "git+https://github.com/gakonst/ethers-rs#28094e8a83a0335f51c79bf0ae7c5d4568db5367"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1130,7 +1185,9 @@ dependencies = [
  "semver 1.0.4",
  "serde 1.0.130",
  "serde_json",
+ "sha2 0.9.8",
  "thiserror",
+ "tracing",
  "walkdir",
 ]
 
@@ -1195,7 +1252,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=master#3d4b17f343fe198de3699971ef3ca35f8796c2e3"
+source = "git+https://github.com/fluidex/common-rs?branch=master#671a92a986920b013e5457a9c2be2b295f1bc733"
 dependencies = [
  "anyhow",
  "babyjubjub-rs",
@@ -1289,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1299,15 +1356,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1316,18 +1373,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -1335,15 +1390,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-timer"
@@ -1353,11 +1408,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1367,8 +1421,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1757,7 +1809,7 @@ checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.10.6",
  "sha2 0.9.8",
  "sha3",
 ]
@@ -2376,7 +2428,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
 dependencies = [
- "der",
+ "der 0.4.0",
  "spki",
 ]
 
@@ -2468,18 +2520,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3172,6 +3212,16 @@ dependencies = [
  "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3264,7 +3314,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
- "der",
+ "der 0.4.0",
 ]
 
 [[package]]
@@ -3433,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "chro
 thiserror = "1.0.25"
 tokio = { version = "1.6.0", features = [ "full" ] }
 tonic = "0.5.2"
+normpath = "0.3"
 
 [dev-dependencies]
 pprof = { version = "0.5", features = [ "flamegraph", "protobuf" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ name = "rollup_state_manager"
 path = "src/bin/main.rs"
 
 [[bin]]
+name = "version_check"
+path = "src/bin/version_check.rs"
+required-features = [ "version_check" ]
+
+[[bin]]
 name = "dump_sled"
 path = "src/bin/dump_sled.rs"
 required-features = [ "persist_sled" ]
@@ -65,6 +70,7 @@ bench_global_state = [ ]
 default = ["persist_sled"]
 windows_build = [ "fluidex-common/rdkafka-dynamic" ]
 fr_string_repr = [ ]
+version_check = [ ]
 persist_sled = [ "sled", "bincode" ]
 
 [profile.release]

--- a/examples/js/get_l2_block_by_id.ts
+++ b/examples/js/get_l2_block_by_id.ts
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require("dotenv").config();
 
 import * as dayjs from "dayjs";
 import { grpcClient } from "./grpc_client";

--- a/examples/js/get_l2_block_by_id.ts
+++ b/examples/js/get_l2_block_by_id.ts
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 import * as dayjs from "dayjs";
 import { grpcClient } from "./grpc_client";
 import { kafkaProducer } from "./kafka_producer";

--- a/examples/js/get_token_balance.ts
+++ b/examples/js/get_token_balance.ts
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 import { grpcClient } from "./grpc_client";
 import { kafkaProducer } from "./kafka_producer";
 import { sleep } from "./util";

--- a/examples/js/get_token_balance.ts
+++ b/examples/js/get_token_balance.ts
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require("dotenv").config();
 
 import { grpcClient } from "./grpc_client";
 import { kafkaProducer } from "./kafka_producer";

--- a/src/bin/version_check.rs
+++ b/src/bin/version_check.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+use std::env;
+
+//this utility check if the circuit submodule has same version as which is specified to used in enviroment
+fn main() {
+    dotenv::dotenv().ok();
+    let circuit_ver = include_str!("../../circuits/circuits.ver");
+    log::info!("circuits version is {}", circuit_ver);
+
+    if let Ok(ver) = env::var("CIRCUIT_VER"){
+        assert_eq!(ver, circuit_ver, "circuit ver ({}) is not consistent with the ver current used: {}", circuit_ver, ver);
+    }
+}

--- a/src/bin/version_check.rs
+++ b/src/bin/version_check.rs
@@ -7,7 +7,11 @@ fn main() {
     let circuit_ver = include_str!("../../circuits/circuits.ver");
     log::info!("circuits version is {}", circuit_ver);
 
-    if let Ok(ver) = env::var("CIRCUIT_VER"){
-        assert_eq!(ver, circuit_ver, "circuit ver ({}) is not consistent with the ver current used: {}", circuit_ver, ver);
+    if let Ok(ver) = env::var("CIRCUIT_VER") {
+        assert_eq!(
+            ver, circuit_ver,
+            "circuit ver ({}) is not consistent with the ver current used: {}",
+            circuit_ver, ver
+        );
     }
 }

--- a/src/grpc/controller.rs
+++ b/src/grpc/controller.rs
@@ -1,12 +1,10 @@
 use crate::config::Settings;
 use crate::state::global::GlobalState;
 use crate::test_utils::types::{get_token_id_by_name, prec_token_id};
-use crate::types::l2::{tx_detail_idx, AmountType, L2BlockSerde, TxType};
+use crate::types::l2::{tx_detail_idx, L2BlockSerde, TxType};
 use core::cmp::min;
 use fluidex_common::db::models::{l2_block, tablenames};
 use fluidex_common::db::DbType;
-use fluidex_common::num_traits::ToPrimitive;
-use fluidex_common::rust_decimal::Decimal;
 use fluidex_common::types::FrExt;
 use fluidex_common::utils::timeutil::FTimestamp;
 use orchestra::rpc::rollup::*;
@@ -77,10 +75,7 @@ impl Controller {
                     debug_assert!(token_id == tx[tx_detail_idx::TOKEN_ID2].0.to_u32());
 
                     let precision = prec_token_id(token_id);
-                    let amount = AmountType::from_encoded_bigint(tx[tx_detail_idx::AMOUNT].0.to_bigint())
-                        .unwrap()
-                        .to_decimal(precision)
-                        .to_string();
+                    let amount = tx[tx_detail_idx::AMOUNT].0.to_decimal(precision).to_string();
 
                     let old_balance = tx[tx_detail_idx::BALANCE1].0.to_decimal(precision).to_string();
                     let new_balance = tx[tx_detail_idx::BALANCE2].0.to_decimal(precision).to_string();
@@ -100,10 +95,7 @@ impl Controller {
                     debug_assert!(token_id == tx[tx_detail_idx::TOKEN_ID2].0.to_u32());
 
                     let precision = prec_token_id(token_id);
-                    let amount = AmountType::from_encoded_bigint(tx[tx_detail_idx::AMOUNT].0.to_bigint())
-                        .unwrap()
-                        .to_decimal(precision)
-                        .to_string();
+                    let amount = tx[tx_detail_idx::AMOUNT].0.to_decimal(precision).to_string();
 
                     let old_balance = tx[tx_detail_idx::BALANCE1].0.to_decimal(precision).to_string();
                     let new_balance = tx[tx_detail_idx::BALANCE2].0.to_decimal(precision).to_string();
@@ -134,10 +126,7 @@ impl Controller {
                     let to_old_balance = to_new_balance.sub(&amount).to_decimal(precision).to_string();
                     let to_new_balance = to_new_balance.to_decimal(precision).to_string();
 
-                    let amount = AmountType::from_encoded_bigint(tx[tx_detail_idx::AMOUNT].0.to_bigint())
-                        .unwrap()
-                        .to_decimal(precision)
-                        .to_string();
+                    let amount = tx[tx_detail_idx::AMOUNT].0.to_decimal(precision).to_string();
 
                     decoded_tx.transfer_tx = Some(TransferTx {
                         from,
@@ -168,14 +157,8 @@ impl Controller {
                     let precision_1to2 = prec_token_id(token_id_1to2);
                     let precision_2to1 = prec_token_id(token_id_2to1);
 
-                    let amount_1to2 =
-                        Decimal::try_from_i128_with_scale(amount1.to_bigint().to_i128().unwrap(), prec_token_id(token_id_1to2))
-                            .unwrap()
-                            .to_string();
-                    let amount_2to1 =
-                        Decimal::try_from_i128_with_scale(amount2.to_bigint().to_i128().unwrap(), prec_token_id(token_id_2to1))
-                            .unwrap()
-                            .to_string();
+                    let amount_1to2 = amount1.to_decimal(prec_token_id(token_id_1to2)).to_string();
+                    let amount_2to1 = amount2.to_decimal(prec_token_id(token_id_2to1)).to_string();
 
                     let account1_token_sell_old_balance = balance1.to_decimal(precision_1to2).to_string();
                     let account1_token_sell_new_balance = balance1.sub(&amount1).to_decimal(precision_1to2).to_string();

--- a/src/test_utils/circuit.rs
+++ b/src/test_utils/circuit.rs
@@ -58,7 +58,7 @@ fn write_circuit(circuit_repo: &Path, test_dir: &Path, source: &CircuitSource) -
     let src_path: PathBuf = source.src.split('/').collect();
 
     let file_content = format!(
-        "include \"{}\";\ncomponent main = {};",
+        "pragma circom 2.0.0;\ninclude \"{}\";\ncomponent main = {};",
         circuit_repo.join(src_path).to_str().unwrap(),
         source.main
     );

--- a/src/types/l2/serialize.rs
+++ b/src/types/l2/serialize.rs
@@ -275,3 +275,27 @@ impl From<l2::L2BlockDetail> for L2BlockSerde {
         }
     }
 }
+
+#[derive(Serialize)]
+pub struct L2PubDataAux {
+    #[serde(rename = "deposit")]
+    pub deposit_txs_pos: Vec<u32>,
+}
+
+impl<'d> From<&'d l2::L2Block> for L2PubDataAux {
+    fn from(origin: &'d l2::L2Block) -> Self {
+        let deposit_txs_pos: Vec<u32> = origin
+            .detail
+            .txs_type
+            .iter()
+            .zip(0..origin.detail.txs_type.len())
+            .filter(|item| {
+                let (t, _) = item;
+                **t == l2::TxType::Deposit
+            })
+            .map(|item| item.1 as u32)
+            .collect();
+
+        L2PubDataAux { deposit_txs_pos }
+    }
+}

--- a/src/types/l2/tx_encode.rs
+++ b/src/types/l2/tx_encode.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 impl EncodingParam for TxDataEncoder {
     fn data_bits(&self) -> usize {
         let mut ret = 0;
-        let scheme_len = self.account_bits * 2 + self.token_bits * 2 + 40 * 1;
+        let scheme_len = 128 * 1 + self.account_bits * 2 + self.token_bits * 1;
         ret = if ret < scheme_len { scheme_len } else { ret };
         let scheme_len = 32 * 2 + self.account_bits * 2 + self.token_bits * 2 + 40 * 4 + self.order_bits * 2;
         ret = if ret < scheme_len { scheme_len } else { ret };
@@ -34,8 +34,7 @@ impl EncodeForScheme for ForCommonTx<'_> {
         encoder.encode_fr(&payload[tx_detail_idx::ACCOUNT_ID1], encoder.account_bits)?;
         encoder.encode_fr(&payload[tx_detail_idx::ACCOUNT_ID2], encoder.account_bits)?;
         encoder.encode_fr(&payload[tx_detail_idx::TOKEN_ID1], encoder.token_bits)?;
-        encoder.encode_fr(&payload[tx_detail_idx::TOKEN_ID2], encoder.token_bits)?;
-        encoder.encode_fr(&payload[tx_detail_idx::AMOUNT], 40)?;
+        encoder.encode_fr(&payload[tx_detail_idx::AMOUNT], 128)?;
 
         Ok(())
     }

--- a/tests/circuit_tests/export_testcases.rs
+++ b/tests/circuit_tests/export_testcases.rs
@@ -1,6 +1,6 @@
 use fluidex_common::non_blocking_tracing;
+use normpath::PathExt;
 use rollup_state_manager::test_utils::circuit;
-use std::fs;
 use std::path::PathBuf;
 
 mod test_l2_block;
@@ -11,7 +11,11 @@ use test_l2_block::get_l2_block_test_case;
 use test_merkletree::get_merkle_tree_test_case;
 
 fn run() -> anyhow::Result<()> {
-    let circuit_repo = fs::canonicalize(PathBuf::from("circuits")).expect("invalid circuits repo path");
+    let circuit_repo = PathBuf::from("circuits")
+        .as_path()
+        .normalize()
+        .expect("invalid circuits repo path")
+        .into_path_buf();
     let test_dir = circuit_repo.join("testdata");
     circuit::write_test_case(&circuit_repo, &test_dir, get_merkle_tree_test_case())?;
     circuit::write_test_case(&circuit_repo, &test_dir, get_l2_block_test_case())?;

--- a/tests/circuit_tests/test_l2_block.rs
+++ b/tests/circuit_tests/test_l2_block.rs
@@ -5,9 +5,7 @@ use rollup_state_manager::account::Account;
 use rollup_state_manager::state::{GlobalState, ManagerWrapper};
 use rollup_state_manager::test_utils::circuit::{CircuitSource, CircuitTestCase, CircuitTestData};
 use rollup_state_manager::test_utils::types::prec_token_id;
-use rollup_state_manager::types::l2::{
-    self, AmountType, DepositTx, L2BlockSerde, L2Key, OrderInput, SpotTradeTx, TransferTx, UpdateKeyTx, WithdrawTx,
-};
+use rollup_state_manager::types::l2::{self, DepositTx, L2BlockSerde, L2Key, OrderInput, SpotTradeTx, TransferTx, UpdateKeyTx, WithdrawTx};
 use serde_json::json;
 
 use rollup_state_manager::params;
@@ -90,7 +88,7 @@ impl Block {
                 DepositTx {
                     token_id: token_id0,
                     account_id: account_id0,
-                    amount: AmountType::from_decimal(&Decimal::new(300, 0), prec_token_id(token_id0)).unwrap(),
+                    amount: Decimal::new(300, 0).to_u64(prec_token_id(token_id0)) as u128,
                     l2key: None,
                 },
                 None,
@@ -115,7 +113,7 @@ impl Block {
             account_id0,
             account_id1,
             token_id0,
-            AmountType::from_decimal(&Decimal::new(100, 0), prec_token_id(token_id0)).unwrap(),
+            Decimal::new(100, 0).to_u64(prec_token_id(token_id0)) as u128,
         );
         transfer_tx0.from_nonce = manager.get_account_nonce(account_id0);
         let hash = transfer_tx0.hash();
@@ -126,7 +124,7 @@ impl Block {
             account_id1,
             account_id0,
             token_id0,
-            AmountType::from_decimal(&Decimal::new(50, 0), prec_token_id(token_id0)).unwrap(),
+            Decimal::new(50, 0).to_u64(prec_token_id(token_id0)) as u128,
         );
         transfer_tx1.from_nonce = manager.get_account_nonce(account_id1);
         let hash = transfer_tx1.hash();
@@ -136,7 +134,7 @@ impl Block {
         let mut withdraw_tx = WithdrawTx::new(
             account_id0,
             token_id0,
-            AmountType::from_decimal(&Decimal::new(150, 0), prec_token_id(token_id0)).unwrap(),
+            Decimal::new(150, 0).to_u64(prec_token_id(token_id0)) as u128,
             manager.get_token_balance(account_id0, token_id0),
         );
         manager.fill_withdraw_tx(&mut withdraw_tx);
@@ -153,7 +151,7 @@ impl Block {
                 DepositTx {
                     account_id: account_id1,
                     token_id: token_id0,
-                    amount: AmountType::from_decimal(&Decimal::new(199, 0), prec_token_id(token_id0)).unwrap(),
+                    amount: Decimal::new(199, 0).to_u64(prec_token_id(token_id0)) as u128,
                     l2key: None,
                 },
                 None,
@@ -177,7 +175,7 @@ impl Block {
                 DepositTx {
                     account_id: account_id2,
                     token_id: token_id1,
-                    amount: AmountType::from_decimal(&Decimal::new(1990, 0), prec_token_id(token_id1)).unwrap(),
+                    amount: Decimal::new(1990, 0).to_u64(prec_token_id(token_id1)) as u128,
                     l2key: None,
                 },
                 None,

--- a/tests/global_state/bench.rs
+++ b/tests/global_state/bench.rs
@@ -2,7 +2,7 @@
 #![allow(unreachable_patterns)]
 use anyhow::Result;
 use fluidex_common::rust_decimal_macros::dec;
-use fluidex_common::types::{Decimal, Float40};
+use fluidex_common::types::{Decimal, DecimalExt};
 use rollup_state_manager::account::Account;
 use rollup_state_manager::msg::msg_processor;
 use rollup_state_manager::params;
@@ -71,8 +71,8 @@ fn bench_with_dummy_transfers() -> Result<()> {
     processor.handle_deposit_msg(&mut manager, deposit.into());
 
     // step3: bench transfer
-    let amount = Float40::from_decimal(&dec!(1), prec_token_id(0)).unwrap();
-    let mut transfer = TransferTx::new(1, 2, 0 /*ETH*/, amount);
+    let amount = dec!(1).to_u64(prec_token_id(0));
+    let mut transfer = TransferTx::new(1, 2, 0 /*ETH*/, amount as u128);
     let transfer_hash = transfer.hash();
     let sig = user1.sign_hash(transfer_hash).unwrap();
     transfer.sig = sig;

--- a/tests/global_state/gen_testcase.rs
+++ b/tests/global_state/gen_testcase.rs
@@ -5,13 +5,13 @@
 #![allow(clippy::unnecessary_wraps)]
 
 use anyhow::Result;
+use normpath::PathExt;
 use rollup_state_manager::params;
 use rollup_state_manager::state::{GlobalState, ManagerWrapper};
 use rollup_state_manager::test_utils;
 use rollup_state_manager::test_utils::circuit::{write_test_case, CircuitTestCase, CircuitTestData};
 use rollup_state_manager::test_utils::messages::WrappedMessage;
 use rollup_state_manager::types::l2::{L2Block, L2BlockSerde};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -90,7 +90,11 @@ fn replay_msgs(
 }
 
 pub fn run(src: &str) -> Result<()> {
-    let circuit_repo = fs::canonicalize(PathBuf::from("circuits")).expect("invalid circuits repo path");
+    let circuit_repo = PathBuf::from("circuits")
+        .as_path()
+        .normalize()
+        .expect("invalid circuits repo path")
+        .into_path_buf();
     let filepath = PathBuf::from(src);
     let (msg_sender, msg_receiver) = crossbeam_channel::unbounded();
     let (blk_sender, blk_receiver) = crossbeam_channel::unbounded();


### PR DESCRIPTION
Now we start to make the system support trustable and stable process for depositing from L1 contract. So every depositing would be ensured to have corresponding effects in the L2 block. We have included following works in this PR

- [x] Consist with [the updating of txdata encoding schemes in circuits](https://github.com/fluidex/circuits/pull/197), so L1 contract can handle the encoded data easily
- [x] Add auxiliary data for handling depositing data
- [x] Add supporting to versionaize the circuits