### PR TITLE
Move `get_user_info` API from exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
+name = "const-oid"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +735,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +800,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 dependencies = [
- "const-oid",
+ "const-oid 0.6.0",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.0",
 ]
 
 [[package]]
@@ -846,8 +873,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
- "der",
- "elliptic-curve",
+ "der 0.4.0",
+ "elliptic-curve 0.10.6",
  "hmac 0.11.0",
  "signature",
 ]
@@ -864,11 +891,25 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.6",
  "ff",
  "generic-array 0.14.4",
  "group",
  "pkcs8",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73d21281779c2c22cade2a4ab34eee34271869942546a364f7d552d30c62434"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "der 0.5.1",
+ "generic-array 0.14.4",
  "rand_core",
  "subtle",
  "zeroize",
@@ -950,11 +991,12 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "ethers-contract",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
@@ -963,8 +1005,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -981,8 +1023,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1002,8 +1044,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1016,15 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.5.5"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
  "cargo_metadata",
  "convert_case",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "ethabi",
  "generic-array 0.14.4",
  "hex",
@@ -1043,20 +1085,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-etherscan"
+version = "0.2.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+dependencies = [
+ "ethers-core",
+ "reqwest",
+ "serde 1.0.130",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "ethers-middleware"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "async-trait",
  "ethers-contract",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
  "futures-util",
  "instant",
  "reqwest",
  "serde 1.0.130",
- "serde-aux",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1067,8 +1122,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1096,13 +1151,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "eth-keystore",
  "ethers-core",
  "futures-executor",
@@ -1117,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#1da62d65d2f8f4110a350cad9e23f02bf9f0ce78"
+source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1130,7 +1185,9 @@ dependencies = [
  "semver 1.0.4",
  "serde 1.0.130",
  "serde_json",
+ "sha2 0.9.8",
  "thiserror",
+ "tracing",
  "walkdir",
 ]
 
@@ -1195,7 +1252,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=master#3d4b17f343fe198de3699971ef3ca35f8796c2e3"
+source = "git+https://github.com/fluidex/common-rs?branch=add-missing-account-mod-in-rollup#48f033c8444bc19ffc06dbaed69a0c5256475717"
 dependencies = [
  "anyhow",
  "babyjubjub-rs",
@@ -1289,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1299,15 +1356,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1316,18 +1373,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -1335,15 +1390,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-timer"
@@ -1353,11 +1408,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1367,8 +1421,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1757,7 +1809,7 @@ checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.10.6",
  "sha2 0.9.8",
  "sha3",
 ]
@@ -2211,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "orchestra"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/orchestra.git?branch=master#182e3ec723f23656a329246cf32c0fc020c2b2c1"
+source = "git+https://github.com/fluidex/orchestra.git?branch=master#7c012af8f65a97475836bdd1a198155608ccf9b0"
 dependencies = [
  "prost",
  "serde 1.0.130",
@@ -2367,7 +2419,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
 dependencies = [
- "der",
+ "der 0.4.0",
  "spki",
 ]
 
@@ -2459,18 +2511,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3162,6 +3202,16 @@ dependencies = [
  "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3254,7 +3304,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
- "der",
+ "der 0.4.0",
 ]
 
 [[package]]
@@ -3423,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1024,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1100,7 +1100,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#9b6cc37ca05cada3d59eed9582803dc4b302bad5"
+source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1252,7 +1252,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=add-missing-account-mod-in-rollup#48f033c8444bc19ffc06dbaed69a0c5256475717"
+source = "git+https://github.com/fluidex/common-rs?branch=master#eb9440fe1c8d4082602a0a850e6599f1901ac6bf"
 dependencies = [
  "anyhow",
  "babyjubjub-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ config_rs = { package = "config", version = "0.10.1" }
 crossbeam-channel = "0.5.1"
 dotenv = "0.15.0"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
-fluidex-common = { git = "https://github.com/fluidex/common-rs", branch = "master", features = [ "kafka", "l2-account", "non-blocking-tracing", "rollup-state-db" ] }
+fluidex-common = { git = "https://github.com/fluidex/common-rs", branch = "add-missing-account-mod-in-rollup", features = [ "kafka", "l2-account", "non-blocking-tracing", "rollup-state-db" ] }
 futures = "0.3.13"
 hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ config_rs = { package = "config", version = "0.10.1" }
 crossbeam-channel = "0.5.1"
 dotenv = "0.15.0"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
-fluidex-common = { git = "https://github.com/fluidex/common-rs", branch = "add-missing-account-mod-in-rollup", features = [ "kafka", "l2-account", "non-blocking-tracing", "rollup-state-db" ] }
+fluidex-common = { git = "https://github.com/fluidex/common-rs", branch = "master", features = [ "kafka", "l2-account", "non-blocking-tracing", "rollup-state-db" ] }
 futures = "0.3.13"
 hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/src/grpc/handler.rs
+++ b/src/grpc/handler.rs
@@ -29,4 +29,8 @@ impl rollup_state_server::RollupState for Handler {
     async fn token_balance_query(&self, request: Request<TokenBalanceQueryRequest>) -> Result<Response<TokenBalanceQueryResponse>, Status> {
         Ok(Response::new(self.controller.token_balance_query(request.into_inner())?))
     }
+
+    async fn user_info_query(&self, request: Request<UserInfoQueryRequest>) -> Result<Response<UserInfoQueryResponse>, Status> {
+        Ok(Response::new(self.controller.user_info_query(request.into_inner()).await?))
+    }
 }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,5 +1,6 @@
 mod controller;
 mod handler;
+mod user_cache;
 
 use crate::grpc::handler::Handler;
 use crate::state::GlobalState;

--- a/src/grpc/user_cache.rs
+++ b/src/grpc/user_cache.rs
@@ -1,0 +1,41 @@
+use fluidex_common::db::models::account::AccountDesc;
+use fluidex_common::fnv::FnvHashMap;
+use std::fmt::Display;
+
+pub struct UserCache {
+    // `id:{}`, `l1_addr:{}` or `l2_pubkey:{}` -> AccountDesc
+    users: FnvHashMap<String, AccountDesc>,
+}
+
+impl UserCache {
+    pub fn new() -> Self {
+        Self {
+            users: FnvHashMap::default(),
+        }
+    }
+
+    pub fn get_user_info(&self, user_id: Option<u32>, l1_address: &Option<String>, l2_pubkey: &Option<String>) -> Option<&AccountDesc> {
+        user_id
+            .and_then(|val| self.users.get(&format_user_id_key(val)))
+            .or_else(|| l1_address.as_ref().and_then(|val| self.users.get(&format_l1_address_key(val))))
+            .or_else(|| l2_pubkey.as_ref().and_then(|val| self.users.get(&format_l2_pubkey_key(val))))
+    }
+
+    pub fn set_user_info(&mut self, user_info: AccountDesc) {
+        self.users.insert(format_user_id_key(&user_info.id), user_info.clone());
+        self.users.insert(format_l1_address_key(&user_info.l1_address), user_info.clone());
+        self.users.insert(format_l2_pubkey_key(&user_info.l2_pubkey), user_info);
+    }
+}
+
+fn format_user_id_key<T: Display>(val: T) -> String {
+    format!("id:{}", val)
+}
+
+fn format_l1_address_key<T: Display>(val: T) -> String {
+    format!("l1_addr:{}", val)
+}
+
+fn format_l2_pubkey_key<T: Display>(val: T) -> String {
+    format!("l2_pubkey:{}", val)
+}


### PR DESCRIPTION
Part of https://github.com/fluidex/rollup-state-manager/issues/245

TODO: Will move and test with API `register_user` in another PR.