### PR TITLE
Trivial update when inducing data avaliability

### DIFF
--- a/examples/js/rest_get_l2_blocks.ts
+++ b/examples/js/rest_get_l2_blocks.ts
@@ -1,3 +1,4 @@
+require("dotenv").config();
 import * as dayjs from "dayjs";
 import { restClient } from "./rest_client";
 import { strict as assert } from "assert";

--- a/src/msg/msg_processor.rs
+++ b/src/msg/msg_processor.rs
@@ -43,7 +43,7 @@ impl Processor {
         let l2_pubkey: Vec<u8> = hex::decode(l2_pubkey.trim_start_matches("0x")).unwrap();
         let bjj_compressed: [u8; 32] = l2_pubkey.try_into().unwrap();
         let l2_pubkey_point: Point = babyjubjub_rs::decompress_point(bjj_compressed).unwrap();
-        let eth_addr = Fr::from_str(&user_info.l1_address);
+        // let eth_addr = Fr::from_str(&user_info.l1_address);
         let sign = if bjj_compressed[31] & 0x80 != 0x00 { Fr::one() } else { Fr::zero() };
         // TODO: remove '0x' from eth addr?
         manager
@@ -51,7 +51,8 @@ impl Processor {
                 l2::UpdateKeyTx {
                     account_id,
                     l2key: l2::L2Key {
-                        eth_addr,
+                        // eth_addr is not used any more
+                        eth_addr: Default::default(),
                         sign,
                         ay: l2_pubkey_point.y,
                     },

--- a/src/test_utils/circuit.rs
+++ b/src/test_utils/circuit.rs
@@ -58,7 +58,7 @@ fn write_circuit(circuit_repo: &Path, test_dir: &Path, source: &CircuitSource) -
     let src_path: PathBuf = source.src.split('/').collect();
 
     let file_content = format!(
-        "pragma circom 2.0.0;\ninclude \"{}\";\ncomponent main = {};",
+        "pragma circom 2.0.0;\ninclude \"{}\";\ncomponent main {{public [oldRoot, newRoot, txDataHashHi, txDataHashLo]}} = {};",
         circuit_repo.join(src_path).to_str().unwrap(),
         source.main
     );

--- a/src/test_utils/circuit.rs
+++ b/src/test_utils/circuit.rs
@@ -58,7 +58,7 @@ fn write_circuit(circuit_repo: &Path, test_dir: &Path, source: &CircuitSource) -
     let src_path: PathBuf = source.src.split('/').collect();
 
     let file_content = format!(
-        "pragma circom 2.0.0;\ninclude \"{}\";\ncomponent main {{public [oldRoot, newRoot, txDataHashHi, txDataHashLo]}} = {};",
+        "pragma circom 2.0.0;\ninclude \"{}\";\ncomponent main = {};",
         circuit_repo.join(src_path).to_str().unwrap(),
         source.main
     );


### PR DESCRIPTION
+ The message generated by matching engine include a malform "eth_addr" which has "0x" prefix. Now we complete prune the reference of L1 addr because L2 block never used it. 